### PR TITLE
update date format

### DIFF
--- a/slider/loop.go
+++ b/slider/loop.go
@@ -153,7 +153,7 @@ func getImages(opts *LoopOptions, selectedTimes []time.Time) ([]image.Image, err
 			for x := 0; x < opts.zoom.NumTiles(); x++ {
 				for y := 0; y < opts.zoom.NumTiles(); y++ {
 					imageTileURL := ImageTileURL(&TileImageRequest{
-						Date:           timestamp.Format("20060102"),
+						Date:           timestamp.Format("2006/01/02"),
 						Satellite:      opts.Satellite.Value,
 						Sector:         opts.Sector.Value,
 						Product:        opts.Product.Value,


### PR DESCRIPTION
When trying the examples I get an error like this:
```
➜  slider-cli git:(main) ./slider-cli --satellite=goes-16 --sector=conus --product=geocolor
4:41PM FTL unable to create loop: unable to get images: unable to download image for timestamp 2022-04-24 14:06:17 +0000 UTC: unable to download image: https://rammb-slider.cira.colostate.edu/data/imagery/20220424/goes-16---conus/geocolor/20220424140617/01/000_000.png: HTTP404
```

It seems they updated the date format in the URL?

A valid URL now has this date format with `2022/04/24`: https://rammb-slider.cira.colostate.edu/data/imagery/2022/04/24/meteosat-8---full_disk/geocolor/20220424120000/03/001_002.png

I did a `make` locally and it seems to work, but didn't fully run any of the other checks.